### PR TITLE
New policies for single topic multi-tenant functionality in other PR to OPAL

### DIFF
--- a/single-topic-multi-tenant/README.md
+++ b/single-topic-multi-tenant/README.md
@@ -1,0 +1,92 @@
+# Single-Topic Multi-Tenant RBAC Example
+
+This directory contains a single-topic multi-tenant RBAC policy example for OPAL.
+
+## Architecture
+
+Traditional multi-tenant OPAL setups require:
+- **N tenants = N topics** (each tenant has its own topic)
+- **Service restarts** when adding new tenants
+- **Complex topic management**
+
+This example demonstrates a revolutionary approach:
+- **N tenants = 1 topic + N data sources** 
+- **Zero restarts** when adding tenants
+- **Dynamic tenant addition** via `/data/config` API
+
+## How it works
+
+1. **Single Topic**: All tenants share one topic `tenant_data`
+2. **External Data Sources**: Each tenant has its own data source configured via API
+3. **Data Isolation**: Tenants are isolated through OPA path hierarchy (`/acl/tenant1`, `/acl/tenant2`)
+4. **Policy Sharing**: All tenants use the same RBAC policy logic
+
+## Policy Structure
+
+- `rbac.rego` - RBAC policy compatible with older OPA versions (no "if" statements)
+- `data.json` - Demo data showing expected structure
+- `.manifest` - Load order specification
+
+## Data Structure
+
+The policy expects data at paths like `/acl/{tenant_id}`:
+
+```json
+{
+  "acl": {
+    "tenant1": {
+      "users": {
+        "alice": {
+          "roles": ["admin"],
+          "location": "US"
+        }
+      },
+      "role_permissions": {
+        "admin": [
+          {"action": "*", "resource": "*"}
+        ]
+      }
+    }
+  }
+}
+```
+
+## Usage with OPAL
+
+1. Configure OPAL Server to use this policy repo
+2. Add tenants dynamically via External Data Sources API:
+
+```bash
+curl -X POST http://opal-server:7002/data/config \
+  -H "Content-Type: application/json" \
+  -d '{
+    "id": "tenant1_data",
+    "entries": [{
+      "url": "http://data-source/tenant1/data",
+      "topics": ["tenant_data"],
+      "dst_path": "/acl/tenant1"
+    }]
+  }'
+```
+
+3. No service restart required!
+
+## Compatibility
+
+This policy is written in older OPA syntax for maximum compatibility:
+- Uses `some` keyword for quantification
+- No `if` statements
+- Compatible with OPA versions prior to v0.20.0
+
+## Testing
+
+Query examples:
+```json
+{
+  "user": "alice",
+  "action": "read",
+  "resource": "documents"
+}
+```
+
+Expected result for admin user: `{"result": true}` 

--- a/single-topic-multi-tenant/data.json
+++ b/single-topic-multi-tenant/data.json
@@ -1,0 +1,44 @@
+{
+  "acl": {
+    "demo": {
+      "users": {
+        "alice": {
+          "roles": ["admin"],
+          "location": "US"
+        },
+        "bob": {
+          "roles": ["editor"],
+          "location": "US"
+        },
+        "charlie": {
+          "roles": ["viewer"],
+          "location": "US"
+        }
+      },
+      "role_permissions": {
+        "admin": [
+          {
+            "action": "*",
+            "resource": "*"
+          }
+        ],
+        "editor": [
+          {
+            "action": "read",
+            "resource": "documents"
+          },
+          {
+            "action": "edit",
+            "resource": "documents"
+          }
+        ],
+        "viewer": [
+          {
+            "action": "read",
+            "resource": "documents"
+          }
+        ]
+      }
+    }
+  }
+} 

--- a/single-topic-multi-tenant/rbac.rego
+++ b/single-topic-multi-tenant/rbac.rego
@@ -1,0 +1,51 @@
+# Multi-Tenant Role-based Access Control (RBAC)
+# Single-Topic Multi-Tenant Architecture Example
+# Compatible with older OPA versions (no "if" statements)
+
+package rbac
+
+import data.acl
+
+# By default, deny requests
+default allow = false
+
+# Allow admin users to do anything
+allow {
+    user_is_admin
+}
+
+# Allow users based on role permissions
+allow {
+    # Find tenant data for this request
+    some tenant_id
+    tenant_data := acl[tenant_id]
+    
+    # Check if user exists in tenant data
+    user_data := tenant_data.users[input.user]
+    
+    # Get user's roles from tenant data
+    some role
+    role := user_data.roles[_]
+    
+    # Get permissions for this role from tenant data
+    permissions := tenant_data.role_permissions[role]
+    
+    # Check if role has permission for this action/resource
+    some permission
+    permission := permissions[_]
+    permission.action == input.action
+    permission.resource == input.resource
+    
+    # Check location restriction (OPAL example compatibility)
+    user_data.location == "US"
+}
+
+# Helper rule to check if user is admin
+user_is_admin {
+    some tenant_id
+    tenant_data := acl[tenant_id]
+    user_data := tenant_data.users[input.user]
+    some role
+    role := user_data.roles[_]
+    role == "admin"
+} 

--- a/single-topic-multi-tenant/rbac.rego
+++ b/single-topic-multi-tenant/rbac.rego
@@ -17,24 +17,21 @@ allow {
 # Allow users based on role permissions
 allow {
     # Find tenant data for this request
-    some tenant_id
-    tenant_data := acl[tenant_id]
+    tenant_data := acl[_]
     
     # Check if user exists in tenant data
     user_data := tenant_data.users[input.user]
     
     # Get user's roles from tenant data
-    some role
-    role := user_data.roles[_]
+    user_role := user_data.roles[_]
     
     # Get permissions for this role from tenant data
-    permissions := tenant_data.role_permissions[role]
+    permissions := tenant_data.role_permissions[user_role]
     
     # Check if role has permission for this action/resource
-    some permission
-    permission := permissions[_]
-    permission.action == input.action
-    permission.resource == input.resource
+    user_permission := permissions[_]
+    user_permission.action == input.action
+    user_permission.resource == input.resource
     
     # Check location restriction (OPAL example compatibility)
     user_data.location == "US"
@@ -42,10 +39,9 @@ allow {
 
 # Helper rule to check if user is admin
 user_is_admin {
-    some tenant_id
-    tenant_data := acl[tenant_id]
+    tenant_data := acl[_]
     user_data := tenant_data.users[input.user]
-    some role
-    role := user_data.roles[_]
-    role == "admin"
-} 
+    admin_role := user_data.roles[_]
+    admin_role == "admin"
+}
+

--- a/single-topic-multi-tenant/rbac.rego
+++ b/single-topic-multi-tenant/rbac.rego
@@ -2,7 +2,7 @@
 # Single-Topic Multi-Tenant Architecture Example
 # Compatible with older OPA versions (no "if" statements)
 
-package rbac
+package multi_tenant_rbac
 
 import data.acl
 
@@ -44,4 +44,3 @@ user_is_admin {
     admin_role := user_data.roles[_]
     admin_role == "admin"
 }
-


### PR DESCRIPTION
Files with example multi-tenant policy are needed to https://github.com/permitio/opal/pull/802 this PR.

**Backward Compatibility Verification Report**
Changes Made:
- Added new policy directory: single-topic-multi-tenant/
- Implemented package multi_tenant_rbac (isolated from existing app.rbac)
Compatibility Testing
- Tested configuration: docker-compose-example.yml with our forked repo
Key finding: Despite lack of OPAL_POLICY_SUBSCRIPTION_DIRS isolation in standard examples, both policies coexist without conflicts:
- Our policy loads: single-topic-multi-tenant/rbac.rego → package multi_tenant_rbac
- Official policy loads: rbac.rego → package app.rbac
- No interference: Different package names prevent conflicts

Official Documentation Tests - **PASSED**!
Full backward compatibility confirmed - existing OPAL examples continue to work unchanged even when our new policy directory is present in the repository.