### PR TITLE
   Add single-topic multi-tenant RBAC example with explicit tenant security

### DIFF
--- a/single-topic-multi-tenant/.manifest
+++ b/single-topic-multi-tenant/.manifest
@@ -1,0 +1,1 @@
+rbac.rego

--- a/single-topic-multi-tenant/rbac.rego
+++ b/single-topic-multi-tenant/rbac.rego
@@ -53,4 +53,4 @@ user_is_admin {
     user_data := tenant_data.users[input.user]
     admin_role := user_data.roles[_]
     admin_role == "admin"
-}
+} 

--- a/single-topic-multi-tenant/rbac.rego
+++ b/single-topic-multi-tenant/rbac.rego
@@ -53,4 +53,4 @@ user_is_admin {
     user_data := tenant_data.users[input.user]
     admin_role := user_data.roles[_]
     admin_role == "admin"
-} 
+}

--- a/single-topic-multi-tenant/rbac.rego
+++ b/single-topic-multi-tenant/rbac.rego
@@ -1,6 +1,7 @@
 # Multi-Tenant Role-based Access Control (RBAC)
 # Single-Topic Multi-Tenant Architecture Example
 # Compatible with older OPA versions (no "if" statements)
+# USES EXPLICIT TENANT_ID for production security
 
 package multi_tenant_rbac
 
@@ -14,12 +15,15 @@ allow {
     user_is_admin
 }
 
-# Allow users based on role permissions
+# Allow users based on role permissions with explicit tenant_id
 allow {
-    # Find tenant data for this request
-    tenant_data := acl[_]
+    # Ensure tenant_id is provided in input
+    input.tenant_id
     
-    # Check if user exists in tenant data
+    # Get tenant data using explicit tenant_id (secure and performant)
+    tenant_data := acl[input.tenant_id]
+    
+    # Check if user exists in this specific tenant
     user_data := tenant_data.users[input.user]
     
     # Get user's roles from tenant data
@@ -37,10 +41,16 @@ allow {
     user_data.location == "US"
 }
 
-# Helper rule to check if user is admin
+# Helper rule to check if user is admin with explicit tenant_id
 user_is_admin {
-    tenant_data := acl[_]
+    # Ensure tenant_id is provided
+    input.tenant_id
+    
+    # Get tenant data using explicit tenant_id
+    tenant_data := acl[input.tenant_id]
+    
+    # Check if user exists and has admin role
     user_data := tenant_data.users[input.user]
     admin_role := user_data.roles[_]
     admin_role == "admin"
-}
+} 


### PR DESCRIPTION
   ## 🏗️ Single-Topic Multi-Tenant RBAC Implementation
   
   This PR introduces a complete single-topic multi-tenant RBAC solution for OPAL that eliminates the need for multiple topics per tenant.
   
   ### 🎯 Key Features
   
   - **🔄 Single Topic Architecture**: All tenants share one topic with N data sources
   - **⚡ Zero Restarts**: Dynamic tenant addition via `/data/config` API  
   - **🔒 Enhanced Security**: Explicit `tenant_id` enforcement prevents cross-tenant access
   - **🧪 Backward Compatible**: Works with older OPA versions (no "if" statements)
   
   ### 📁 Files Added
   
   - `single-topic-multi-tenant/rbac.rego` - Multi-tenant RBAC policy with explicit security
   - `single-topic-multi-tenant/data.json` - Demo data structure
   - `single-topic-multi-tenant/README.md` - Complete documentation  
   - `single-topic-multi-tenant/.manifest` - OPAL load order specification
   
   ### 🛡️ Security Improvements (Latest Commit)
   
   - **Explicit Tenant ID**: Requires `input.tenant_id` in all requests
   - **Direct Access**: Uses `acl[input.tenant_id]` instead of `acl[_]` iteration
   - **Tenant Isolation**: Prevents accidental cross-tenant data access
   - **Performance**: Eliminates unnecessary tenant data iterations
   
   ### 🧪 Usage
   
   ```json
   {
     "user": "alice",
     "action": "read", 
     "resource": "documents",
     "tenant_id": "demo"
   }
   ```
   
   This implementation is ready for production use and demonstrates OPAL's capability for scalable multi-tenant authorization.